### PR TITLE
Suppress run on non Linux OS and add German translation

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -87,5 +87,10 @@ port.onMessage.addListener(function (message) {
 	}
 });
 
-GSC.update.init();
-GSC.notifications.restore();
+chrome.runtime.getPlatformInfo(function(info) {
+	if (["linux", "openbsd"].indexOf(info.os) !== -1)
+	{
+		GSC.update.init();
+		GSC.notifications.restore();
+	}
+});


### PR DESCRIPTION
Hi, the extension always showed an error dialog, while I used Google Chrome besides Linux under Windows OS. I guess many people do sync their Chrome profile across different OS, so this would be useful to have.

I did also add a German translation file.
