### PR TITLE
Add a link to a PKGBUILD I made for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ For Gentoo Linux ebuild is available in vortex overlay. If you use Layman just t
 layman -a vortex
 emerge -av gnome-extra/gs-chrome-connector
 ```
+For Arch Linux there is a PKGBUILD avaiable in the AUR: [gs-chrome-connector](https://aur.archlinux.org/packages/gs-chrome-connector-git/)
+
 If there is no native connector package in your distro you can install it using cmake or manually.
 
 Manual installation


### PR DESCRIPTION
This just adds a link in the readme for any Arch Linux users wanting to install the native connector easily via the AUR.
https://github.com/winsock/gs-chrome-connector-aur
https://aur.archlinux.org/packages/gs-chrome-connector-git/
